### PR TITLE
Rename vault area to cedar

### DIFF
--- a/floor.svg
+++ b/floor.svg
@@ -8325,7 +8325,7 @@
    style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#800080;fill-opacity:1;stroke:none;font-family:Futura;-inkscape-font-specification:Futura Medium"
    x="377.15433"
    y="738.77057"
-   id="vault"
+   id="cedar"
    class="team"
    sodipodi:linespacing="125%"
    inkscape:transform-center-y="-15.478516"
@@ -8333,7 +8333,7 @@
      sodipodi:role="line"
      id="tspan6625"
      x="377.15433"
-     y="738.77057">vault</tspan></text>
+     y="738.77057">cedar</tspan></text>
 
 
 

--- a/floor.svg
+++ b/floor.svg
@@ -8342,7 +8342,7 @@
    style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#800080;fill-opacity:1;stroke:none;font-family:Futura;-inkscape-font-specification:Futura Medium"
    x="492.30319"
    y="748.78351"
-   id="text5260"
+   id="product"
    class="team"
    sodipodi:linespacing="125%"
    transform="translate(39.340691,613.245)"><tspan


### PR DESCRIPTION
1. Renames `vault` area to `cedar`

1. Changes the ID for the `product` area so that office.heroku.com/#product is possible (instead of `text5260`)