### PR TITLE
Reduced SVG anchor scroll bug.

### DIFF
--- a/public_html/scroll-test.html
+++ b/public_html/scroll-test.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<title>SVG Scroll Test</title>
+
+</head>
+<body>
+
+<p>
+<a href="#red">Red</a> | 
+<a href="#green">Green</a> |
+<a href="#blue">Blue</a>
+</p>
+
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="0 0 100 4000" height="4000" width="100" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#FF050C;}
+  .st1{fill:#2B51FF;}
+  .st2{fill:#2BF900;}
+</style>
+<polygon id="red" class="st0" points="50.5,25.3 64,52.7 94.2,57.1 72.4,78.4 77.5,108.5 50.5,94.3 23.5,108.5 28.6,78.4 6.8,57.1 37,52.7 
+  "/>
+<polygon id="green" class="st1" points="49.5,1852.3 63,1879.7 93.2,1884.1 71.4,1905.4 76.5,1935.5 49.5,1921.3 22.5,1935.5 27.6,1905.4 
+  5.8,1884.1 36,1879.7 "/>
+<polygon id="blue" class="st2" points="49.5,3897.3 63,3924.7 93.2,3929.1 71.4,3950.4 76.5,3980.5 49.5,3966.3 22.5,3980.5 27.6,3950.4 
+  5.8,3929.1 36,3924.7 "/>
+</svg>
+
+
+</body>
+</html>


### PR DESCRIPTION
:construction: For review only. Do not merge. :construction: 

I tried to fix the anchor scrolling bug #8. I couldn't, so tried reducing the SVG anchor scrolling behavior in a separate test document.

Visit `scroll-test.html` on this branch. There are three stars: red, green, and blue, with named anchors `#red`, `#green`, & `#blue`. Witness how those anchors do not scroll correctly in this terrifically simple HTML document.

@jesperfj you didn't break it :wine_glass: 